### PR TITLE
Fix test for Mojolicious 9.11

### DIFF
--- a/t/app.t
+++ b/t/app.t
@@ -7,7 +7,7 @@ use Mojolicious::Lite;
 plugin 'TextExceptions';
 
 get '/'    => sub { die "horribly" };
-get '/api' => sub { die "horribly" };
+get '/api' => [format => ['json']] => {format => undef} => sub { die "horribly" };
 
 my $t = Test::Mojo->new;
 


### PR DESCRIPTION
Mojo 9.11+ disables automatic format detection so a test needs
adjusting.

Fixes #1.